### PR TITLE
Allow arbitrary Redis client options to be passed via plugin config

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Catalyst-Plugin-Session-Store-Redis
 
+0.04    April 20, 2016
+    - Allow arbitrary configuration keys to be passed to Redis constructor
+
 0.03    December 12th, 2009
     - Fix POD description
     - Fix logging typo (said 'Getting key' when it meant 'Setting key')

--- a/README
+++ b/README
@@ -13,7 +13,10 @@ SYNOPSIS
     MyApp->config->{session} = {
         expires => 3600,
         redis_server => '127.0.0.1:6379',
-        redis_debug => 0 # or 1!
+        redis_debug => 0, # or 1!
+        redis_password => 'password',
+        redis_reconnect => 60,
+        redis_every => 5000,
     };
 
     # ... in an action:


### PR DESCRIPTION
The current version of the module only recognizes redis_server and
redis_debug, which does not permit module users to use a redis server
that requires authentication, or to tune reconnection parameters.

This patch modifies Redis.pm to pass every config key beginning with
redis_ to the Redis client constructor.

Signed-off-by: Chase Venters chase.venters@chaseventers.com
